### PR TITLE
Replace dropdown auth with Google sign-in modal

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -94,7 +94,7 @@ const Header = () => {
                 </DropdownMenuContent>
               </DropdownMenu>
             ) : (
-              <Button variant="secondary" size="sm" className="h-8 px-3" onClick={() => setIsMenuOpen(false)} aria-haspopup="dialog" aria-expanded="true" id="open-google-auth">
+              <Button variant="secondary" size="sm" className="h-8 px-3" onClick={() => { setIsMenuOpen(false); setAuthOpen(true); }} aria-haspopup="dialog" aria-expanded={authOpen} id="open-google-auth">
                 <User className="w-4 h-4 mr-2" /> Sign In
               </Button>
             )}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -93,20 +93,9 @@ const Header = () => {
                 </DropdownMenuContent>
               </DropdownMenu>
             ) : (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button variant="secondary" size="sm" className="h-8 px-3">
-                    <User className="w-4 h-4 mr-2" /> Sign In
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuLabel>Sign in as</DropdownMenuLabel>
-                  <DropdownMenuItem onClick={() => { signIn('viewer'); navigate('/profile'); }}>Viewer</DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => { signIn('contributor'); navigate('/profile'); }}>Contributor</DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => { signIn('admin'); navigate('/profile'); }}>Admin</DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => { signIn('superAdmin'); navigate('/profile'); }}>Super-admin</DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
+              <Button variant="secondary" size="sm" className="h-8 px-3" onClick={() => setIsMenuOpen(false)} aria-haspopup="dialog" aria-expanded="true" id="open-google-auth">
+                <User className="w-4 h-4 mr-2" /> Sign In
+              </Button>
             )}
           </div>
         </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,8 +3,9 @@ import { Link, useLocation, useNavigate } from "react-router-dom";
 import { BookOpen, Menu, Upload, User } from "lucide-react";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
-import { getCurrentUser, signIn, signOut } from "@/lib/auth";
+import { getCurrentUser, signOut } from "@/lib/auth";
 import { Button } from "@/components/ui/button";
+import GoogleAuthModal from "@/components/auth/GoogleAuthModal";
 
 const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,6 +13,7 @@ const Header = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const [currentUser, setCurrentUser] = useState<any>(null);
+  const [authOpen, setAuthOpen] = useState(false);
 
   useEffect(() => {
     const onScroll = () => setIsScrolled(window.scrollY > 4);

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -151,6 +151,7 @@ const Header = () => {
           )}
         </div>
       </div>
+      <GoogleAuthModal open={authOpen} onOpenChange={setAuthOpen} onSignedIn={() => navigate('/profile')} />
     </header>
   );
 };

--- a/src/components/auth/GoogleAuthModal.tsx
+++ b/src/components/auth/GoogleAuthModal.tsx
@@ -56,6 +56,8 @@ const GoogleAuthModal = ({ open, onOpenChange, onSignedIn }: GoogleAuthModalProp
     }
   };
 
+  const isDev = import.meta.env.MODE !== 'production';
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[420px]">
@@ -91,6 +93,18 @@ const GoogleAuthModal = ({ open, onOpenChange, onSignedIn }: GoogleAuthModalProp
             <div className="flex flex-col gap-2">
               <Button onClick={handleCreate} disabled={disabled}><UserPlus className="w-4 h-4 mr-2"/>Create account</Button>
               <Button variant="outline" onClick={()=> setStep('signin')}>Back</Button>
+            </div>
+          </div>
+        )}
+
+        {isDev && (
+          <div className="mt-6 border-t pt-4">
+            <div className="text-xs font-medium text-muted-foreground mb-2">Developer quick sign-in</div>
+            <div className="grid grid-cols-2 gap-2">
+              <Button variant="outline" size="sm" onClick={()=> { signIn('viewer'); onOpenChange(false); onSignedIn?.(); }}>Viewer</Button>
+              <Button variant="outline" size="sm" onClick={()=> { signIn('contributor'); onOpenChange(false); onSignedIn?.(); }}>Contributor</Button>
+              <Button variant="outline" size="sm" onClick={()=> { signIn('admin'); onOpenChange(false); onSignedIn?.(); }}>Admin</Button>
+              <Button variant="outline" size="sm" onClick={()=> { signIn('superAdmin'); onOpenChange(false); onSignedIn?.(); }}>Super-admin</Button>
             </div>
           </div>
         )}

--- a/src/components/auth/GoogleAuthModal.tsx
+++ b/src/components/auth/GoogleAuthModal.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useMemo, useState } from "react";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { signInWithGoogleDefault, signInWithGoogleEmail, createAccountWithGoogle } from "@/lib/auth";
+import { Mail, UserPlus } from "lucide-react";
+
+interface GoogleAuthModalProps {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  onSignedIn?: () => void;
+}
+
+const GoogleAuthModal = ({ open, onOpenChange, onSignedIn }: GoogleAuthModalProps) => {
+  const [step, setStep] = useState<'signin' | 'create'>('signin');
+  const [email, setEmail] = useState('');
+  const [name, setName] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setStep('signin');
+      setEmail('');
+      setName('');
+      setError(null);
+    }
+  }, [open]);
+
+  const disabled = useMemo(() => step === 'signin' ? email.trim() === '' : (email.trim() === '' || name.trim() === ''), [step, email, name]);
+
+  const handleContinueDefault = () => {
+    signInWithGoogleDefault();
+    onOpenChange(false);
+    onSignedIn?.();
+  };
+
+  const handleNext = () => {
+    setError(null);
+    const res = signInWithGoogleEmail(email.trim());
+    if (res.ok) {
+      onOpenChange(false);
+      onSignedIn?.();
+    } else {
+      setStep('create');
+    }
+  };
+
+  const handleCreate = () => {
+    setError(null);
+    if (!name.trim()) return setError('Name is required');
+    const result = createAccountWithGoogle(name.trim(), email.trim());
+    if ((result as any).ok) {
+      onOpenChange(false);
+      onSignedIn?.();
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[420px]">
+        <DialogHeader>
+          <DialogTitle>{step === 'signin' ? 'Sign in with Google' : 'Create your account'}</DialogTitle>
+        </DialogHeader>
+
+        {step === 'signin' ? (
+          <div className="space-y-4 py-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="email">Email</Label>
+              <Input id="email" type="email" placeholder="you@example.com" value={email} onChange={(e)=> setEmail(e.target.value)} />
+            </div>
+            <div className="text-xs text-muted-foreground">Use your college Gmail to sign in. If it doesn't exist, you'll be able to create an account.</div>
+            {error && <div className="text-sm text-destructive">{error}</div>}
+            <div className="flex flex-col gap-2">
+              <Button onClick={handleNext} disabled={disabled}><Mail className="w-4 h-4 mr-2"/>Next</Button>
+              <Button variant="secondary" onClick={handleContinueDefault}>Continue with Google (Test)</Button>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-4 py-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="create-email">Email</Label>
+              <Input id="create-email" type="email" value={email} onChange={(e)=> setEmail(e.target.value)} />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="name">Full name</Label>
+              <Input id="name" placeholder="Your name" value={name} onChange={(e)=> setName(e.target.value)} />
+            </div>
+            <div className="text-xs text-muted-foreground">Your account will be created and signed in. Roles can be assigned later by admins.</div>
+            {error && <div className="text-sm text-destructive">{error}</div>}
+            <div className="flex flex-col gap-2">
+              <Button onClick={handleCreate} disabled={disabled}><UserPlus className="w-4 h-4 mr-2"/>Create account</Button>
+              <Button variant="outline" onClick={()=> setStep('signin')}>Back</Button>
+            </div>
+          </div>
+        )}
+
+        <DialogFooter />
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default GoogleAuthModal;

--- a/src/components/auth/GoogleAuthModal.tsx
+++ b/src/components/auth/GoogleAuthModal.tsx
@@ -3,7 +3,7 @@ import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { signInWithGoogleDefault, signInWithGoogleEmail, createAccountWithGoogle } from "@/lib/auth";
+import { signInWithGoogleDefault, signInWithGoogleEmail, createAccountWithGoogle, signIn } from "@/lib/auth";
 import { Mail, UserPlus } from "lucide-react";
 
 interface GoogleAuthModalProps {


### PR DESCRIPTION
## Purpose

The user requested to implement a proper Google sign-in UI flow instead of the simple dropdown role selection. They wanted:
- A Google sign-in modal that opens when clicking the sign-in button
- Support for both existing users and new account creation
- Mock authentication for testing purposes with default accounts
- Developer buttons for quick role-based sign-in during development
- Proper sign-out handling that updates the profile page state

## Code changes

- **Header.tsx**: Replaced dropdown menu with a single "Sign In" button that opens the Google auth modal
- **GoogleAuthModal.tsx**: New modal component with two-step flow:
  - Step 1: Email input with "Continue with Google (Test)" option
  - Step 2: Account creation form if user doesn't exist
  - Developer quick sign-in buttons for different roles (dev mode only)
- **auth.ts**: Added new authentication functions:
  - `signInWithGoogleDefault()` for test account sign-in
  - `signInWithGoogleEmail()` to check existing users
  - `createAccountWithGoogle()` for new account creation
  - Custom user storage system for created accounts
- **Profile.tsx**: Added auth change listeners to properly handle sign-out and navigate back to home page

The implementation provides a realistic Google sign-in experience while maintaining mock functionality for testing.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/02dd056e48c74bd6b43e171c1d2a260d/aura-forge)

👀 [Preview Link](https://02dd056e48c74bd6b43e171c1d2a260d-aura-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>02dd056e48c74bd6b43e171c1d2a260d</projectId>-->
<!--<branchName>aura-forge</branchName>-->